### PR TITLE
New release

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Speckle
 qgisMinimumVersion=3.0
 description=Speckle 2.0 Connector for QGIS
-version=0.2.0
+version=0.3.0
 author=Speckle Systems
 email=hello@speckle.systems
 

--- a/plugin_utils/installDependencies.py
+++ b/plugin_utils/installDependencies.py
@@ -21,7 +21,7 @@ def setup():
         # just in case the included version is old
         subprocess_call([pythonExec, "-m", "pip", "install", "--upgrade", "pip"])
 
-    pkgVersion = "2.6.4" #"2.5.3"
+    pkgVersion = "2.7.4"  # "2.5.3"
     pkgName = "specklepy"
     try:
         import specklepy
@@ -31,18 +31,9 @@ def setup():
             [pythonExec, "-m", "pip", "install", f"{pkgName}=={pkgVersion}"]
         )
 
-    pkgVersion = "1.10.11" #"2.5.3"
-    pkgName = "panda3d"
-    try:
-        import panda3d
-    except Exception as e:
-        logger.log("panda3d not installed")
-        subprocess_call(
-            [pythonExec, "-m", "pip", "install", f"{pkgName}=={pkgVersion}"]
-        )
-
     # Check if specklpy needs updating
     try:
+        logger.log(f"Attempting to update specklepy to {pkgVersion}")
         subprocess_call(
             [
                 pythonExec,
@@ -55,3 +46,13 @@ def setup():
         )
     except Exception as e:
         logger.logToUser(e.with_traceback)
+
+    pkgVersion = "1.10.11"  # "2.5.3"
+    pkgName = "panda3d"
+    try:
+        import panda3d
+    except Exception as e:
+        logger.log("panda3d not installed")
+        subprocess_call(
+            [pythonExec, "-m", "pip", "install", f"{pkgName}=={pkgVersion}"]
+        )

--- a/plugin_utils/installDependencies.py
+++ b/plugin_utils/installDependencies.py
@@ -31,6 +31,16 @@ def setup():
             [pythonExec, "-m", "pip", "install", f"{pkgName}=={pkgVersion}"]
         )
 
+    pkgVersion = "1.10.11" #"2.5.3"
+    pkgName = "panda3d"
+    try:
+        import panda3d
+    except Exception as e:
+        logger.log("panda3d not installed")
+        subprocess_call(
+            [pythonExec, "-m", "pip", "install", f"{pkgName}=={pkgVersion}"]
+        )
+
     # Check if specklpy needs updating
     try:
         subprocess_call(

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -18,9 +18,10 @@ from speckle.converter.geometry.polyline import (
     circleToNative,
     arcToNative,
     arcToSpeckle,
+    polycurveToNative,
 )
 from specklepy.objects import Base
-from specklepy.objects.geometry import Line, Mesh, Point, Polyline, Curve, Arc, Circle
+from specklepy.objects.geometry import Line, Mesh, Point, Polyline, Curve, Arc, Circle, Polycurve
 
 
 def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
@@ -73,6 +74,7 @@ def convertToNative(base: Base) -> Union[QgsGeometry, None]:
         (Arc, arcToNative),
         (Circle, circleToNative),
         (Mesh, meshToNative),
+        (Polycurve, polycurveToNative),
         (Base, polygonToNative), # temporary solution for polygons (Speckle has no type Polygon yet)
     ]
 

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -11,10 +11,11 @@ from speckle.converter.geometry.polygon import *
 from speckle.converter.geometry.polyline import (
     lineToNative,
     polylineToNative,
+    curveToNative,
     polylineToSpeckle,
 )
 from specklepy.objects import Base
-from specklepy.objects.geometry import Line, Mesh, Point, Polyline
+from specklepy.objects.geometry import Line, Mesh, Point, Polyline, Curve
 
 
 def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
@@ -56,6 +57,7 @@ def convertToNative(base: Base) -> Union[QgsGeometry, None]:
         (Point, pointToNative),
         (Line, lineToNative),
         (Polyline, polylineToNative),
+        (Curve, curveToNative),
         (Mesh, meshToNative),
         (Base, polygonToNative), # temporary solution for polygons (Speckle has no type Polygon yet)
     ]

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -37,21 +37,21 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
     if geomType == QgsWkbTypes.PointGeometry:
         # the geometry type can be of single or multi type
         if geomSingleType:
-            return pointToSpeckle(geom.constGet())
+            return pointToSpeckle(geom.constGet(), feature, layer)
         else:
-            return [pointToSpeckle(pt) for pt in geom.parts()]
+            return [pointToSpeckle(pt, feature, layer) for pt in geom.parts()]
     
     elif geomType == QgsWkbTypes.LineGeometry:
         if type == QgsWkbTypes.CircularString or type == QgsWkbTypes.CircularStringZ or type == QgsWkbTypes.CircularStringM or type == QgsWkbTypes.CircularStringZM: #Type (not GeometryType)
             if geomSingleType:
-                return arcToSpeckle(geom)
+                return arcToSpeckle(geom, feature, layer)
             else:
-                return [arcToSpeckle(poly) for poly in geom.parts()]
+                return [arcToSpeckle(poly, feature, layer) for poly in geom.parts()]
 
         if geomSingleType:
-            return polylineToSpeckle(geom)
+            return polylineToSpeckle(geom, feature, layer)
         else:
-            return [polylineToSpeckle(poly) for poly in geom.parts()]
+            return [polylineToSpeckle(poly, feature, layer) for poly in geom.parts()]
     elif geomType == QgsWkbTypes.PolygonGeometry:
         if geomSingleType:
             return polygonToSpeckle(geom, feature, layer)

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -4,7 +4,9 @@ from numpy import isin
 from speckle.logging import logger
 from typing import List, Union
 
-from qgis.core import QgsGeometry, QgsWkbTypes, QgsMultiPoint, QgsAbstractGeometry, QgsMultiLineString, QgsMultiPolygon
+from qgis.core import (QgsGeometry, QgsWkbTypes, QgsMultiPoint, 
+    QgsAbstractGeometry, QgsMultiLineString, QgsMultiPolygon,
+    QgsCircularString,)
 from speckle.converter.geometry.mesh import meshToNative
 from speckle.converter.geometry.point import pointToNative, pointToSpeckle
 from speckle.converter.geometry.polygon import *
@@ -13,9 +15,12 @@ from speckle.converter.geometry.polyline import (
     polylineToNative,
     curveToNative,
     polylineToSpeckle,
+    circleToNative,
+    arcToNative,
+    arcToSpeckle,
 )
 from specklepy.objects import Base
-from specklepy.objects.geometry import Line, Mesh, Point, Polyline, Curve
+from specklepy.objects.geometry import Line, Mesh, Point, Polyline, Curve, Arc, Circle
 
 
 def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
@@ -27,7 +32,6 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
         geom: QgsGeometry = feature
     geomSingleType = QgsWkbTypes.isSingleType(geom.wkbType())
     geomType = geom.type()
-    #print(geom)
 
     if geomType == QgsWkbTypes.PointGeometry:
         # the geometry type can be of single or multi type
@@ -35,6 +39,7 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
             return pointToSpeckle(geom.constGet())
         else:
             return [pointToSpeckle(pt) for pt in geom.parts()]
+    
     elif geomType == QgsWkbTypes.LineGeometry:
         if geomSingleType:
             return polylineToSpeckle(geom)
@@ -58,6 +63,8 @@ def convertToNative(base: Base) -> Union[QgsGeometry, None]:
         (Line, lineToNative),
         (Polyline, polylineToNative),
         (Curve, curveToNative),
+        (Arc, arcToNative),
+        (Circle, circleToNative),
         (Mesh, meshToNative),
         (Base, polygonToNative), # temporary solution for polygons (Speckle has no type Polygon yet)
     ]

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -32,6 +32,7 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
         geom: QgsGeometry = feature
     geomSingleType = QgsWkbTypes.isSingleType(geom.wkbType())
     geomType = geom.type()
+    type = geom.wkbType()
 
     if geomType == QgsWkbTypes.PointGeometry:
         # the geometry type can be of single or multi type
@@ -41,6 +42,12 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
             return [pointToSpeckle(pt) for pt in geom.parts()]
     
     elif geomType == QgsWkbTypes.LineGeometry:
+        if type == QgsWkbTypes.CircularString or type == QgsWkbTypes.CircularStringZ or type == QgsWkbTypes.CircularStringM or type == QgsWkbTypes.CircularStringZM: #Type (not GeometryType)
+            if geomSingleType:
+                return arcToSpeckle(geom)
+            else:
+                return [arcToSpeckle(poly) for poly in geom.parts()]
+
         if geomSingleType:
             return polylineToSpeckle(geom)
         else:

--- a/speckle/converter/geometry/__init__.py
+++ b/speckle/converter/geometry/__init__.py
@@ -26,7 +26,7 @@ def convertToSpeckle(feature, layer) -> Union[Base, Sequence[Base], None]:
         geom: QgsGeometry = feature
     geomSingleType = QgsWkbTypes.isSingleType(geom.wkbType())
     geomType = geom.type()
-    #print(geomType)
+    #print(geom)
 
     if geomType == QgsWkbTypes.PointGeometry:
         # the geometry type can be of single or multi type

--- a/speckle/converter/geometry/point.py
+++ b/speckle/converter/geometry/point.py
@@ -6,6 +6,7 @@ from qgis.core import (
 )
 
 from specklepy.objects.geometry import Point
+from speckle.converter.layers.utils import get_scale_factor
 
 def pointToSpeckle(pt: QgsPoint or QgsPointXY):
     """Converts a QgsPoint to Speckle"""
@@ -24,5 +25,13 @@ def pointToSpeckle(pt: QgsPoint or QgsPointXY):
 
 def pointToNative(pt: Point) -> QgsPoint:
     """Converts a Speckle Point to QgsPoint"""
+    pt = scalePointToNative(pt, pt.units)
     return QgsPoint(pt.x, pt.y, pt.z)
 
+def scalePointToNative(pt: Point, units: str) -> Point:
+    """Scale point coordinates to meters"""
+    scaleFactor = get_scale_factor(units)
+    pt.x = pt.x * scaleFactor
+    pt.y = pt.y * scaleFactor
+    pt.z = 0 if math.isnan(pt.z) else pt.z * scaleFactor
+    return pt

--- a/speckle/converter/geometry/point.py
+++ b/speckle/converter/geometry/point.py
@@ -7,7 +7,7 @@ from qgis.core import (
 
 from specklepy.objects.geometry import Point
 from speckle.converter.layers.utils import get_scale_factor
-from speckle.converter.geometry.transform import featureColorfromNativeRenderer
+from speckle.converter.layers.symbology import featureColorfromNativeRenderer
 #from PyQt5.QtGui import QColor
 
 def pointToSpeckle(pt: QgsPoint or QgsPointXY, feature: QgsFeature, layer: QgsVectorLayer):

--- a/speckle/converter/geometry/point.py
+++ b/speckle/converter/geometry/point.py
@@ -2,13 +2,15 @@ import math
 
 from qgis.core import (
     QgsPoint,
-    QgsPointXY
+    QgsPointXY, QgsFeature, QgsVectorLayer
 )
 
 from specklepy.objects.geometry import Point
 from speckle.converter.layers.utils import get_scale_factor
+from speckle.converter.geometry.transform import featureColorfromNativeRenderer
+#from PyQt5.QtGui import QColor
 
-def pointToSpeckle(pt: QgsPoint or QgsPointXY):
+def pointToSpeckle(pt: QgsPoint or QgsPointXY, feature: QgsFeature, layer: QgsVectorLayer):
     """Converts a QgsPoint to Speckle"""
     if isinstance(pt, QgsPointXY):
         pt = QgsPoint(pt)
@@ -20,6 +22,10 @@ def pointToSpeckle(pt: QgsPoint or QgsPointXY):
     specklePoint.x = x
     specklePoint.y = y
     specklePoint.z = z
+
+    col = featureColorfromNativeRenderer(feature, layer)
+    specklePoint['displayStyle'] = {}
+    specklePoint['displayStyle']['color'] = col
     return specklePoint
 
 

--- a/speckle/converter/geometry/polygon.py
+++ b/speckle/converter/geometry/polygon.py
@@ -41,26 +41,27 @@ def polygonToSpeckle(geom, feature: QgsFeature, layer: QgsVectorLayer):
         polygon.voids = voids
         polygon.displayValue = [ boundary ] + voids
 
-        if len(voids) == 0: # if there is a mesh with no voids 
-            vertices = []
-            total_vertices = 0
-            for pt in pointList:
-                if isinstance(pt, QgsPointXY):
-                    pt = QgsPoint(pt)
-                x = pt.x()
-                y = pt.y()
-                z = 0 if math.isnan(pt.z()) else pt.z()
-                vertices.extend([x, y, z])
-                total_vertices += 1
+        #if len(voids) == 0: # if there is a mesh with no voids 
+        vertices = []
+        total_vertices = 0
+        for pt in pointList:
+            if isinstance(pt, QgsPointXY):
+                pt = QgsPoint(pt)
+            x = pt.x()
+            y = pt.y()
+            z = 0 if math.isnan(pt.z()) else pt.z()
+            vertices.extend([x, y, z])
+            total_vertices += 1
 
-            ran = range(0, total_vertices)
-            faces = [total_vertices]
-            faces.extend([i for i in ran])
+        ran = range(0, total_vertices)
+        faces = [total_vertices]
+        faces.extend([i for i in ran])
 
-            col = featureColorfromNativeRenderer(feature, layer)
-            colors = [col for i in ran] # apply same color for all vertices
-            mesh = rasterToMesh(vertices, faces, colors)
-            polygon.displayValue = mesh 
+        col = featureColorfromNativeRenderer(feature, layer)
+        colors = [col for i in ran] # apply same color for all vertices
+        mesh = rasterToMesh(vertices, faces, colors)
+        polygon.displayValue = mesh 
+        
         return polygon
     except: 
         logger.logToUser("Some polygons might be invalid", Qgis.Warning)

--- a/speckle/converter/geometry/polygon.py
+++ b/speckle/converter/geometry/polygon.py
@@ -6,6 +6,7 @@ from qgis.core import (
 from typing import Sequence
 
 from specklepy.objects import Base
+from specklepy.objects.geometry import Point
 
 from speckle.converter.geometry.mesh import rasterToMesh
 from speckle.converter.geometry.polyline import (
@@ -15,6 +16,9 @@ from speckle.converter.geometry.polyline import (
 from speckle.converter.layers.symbology import featureColorfromNativeRenderer
 from speckle.logging import logger
 import math
+
+from panda3d.core import Triangulator
+
 from PyQt5.QtGui import QColor
 
 
@@ -41,22 +45,60 @@ def polygonToSpeckle(geom, feature: QgsFeature, layer: QgsVectorLayer):
         polygon.voids = voids
         polygon.displayValue = [ boundary ] + voids
 
-        #if len(voids) == 0: # if there is a mesh with no voids 
         vertices = []
         total_vertices = 0
-        for pt in pointList:
-            if isinstance(pt, QgsPointXY):
-                pt = QgsPoint(pt)
-            x = pt.x()
-            y = pt.y()
-            z = 0 if math.isnan(pt.z()) else pt.z()
-            vertices.extend([x, y, z])
-            total_vertices += 1
 
-        ran = range(0, total_vertices)
-        faces = [total_vertices]
-        faces.extend([i for i in ran])
-        # else: https://docs.panda3d.org/1.10/python/reference/panda3d.core.Triangulator
+        if len(voids) == 0: # if there is a mesh with no voids
+            for pt in pointList:
+                if isinstance(pt, QgsPointXY):
+                    pt = QgsPoint(pt)
+                x = pt.x()
+                y = pt.y()
+                z = 0 if math.isnan(pt.z()) else pt.z()
+                vertices.extend([x, y, z])
+                total_vertices += 1
+
+            ran = range(0, total_vertices)
+            faces = [total_vertices]
+            faces.extend([i for i in ran])
+            # else: https://docs.panda3d.org/1.10/python/reference/panda3d.core.Triangulator
+        else:
+            trianglator = Triangulator()
+            faces = []
+
+            # add boundary points
+            polyBorder = boundary.as_points()
+            pt_count = 0
+            # add extra middle point for border
+            for pt in polyBorder:
+              if pt_count < len(polyBorder)-1: 
+                  pt2 = polyBorder[pt_count+1]
+              else: pt2 = polyBorder[0]
+              
+              trianglator.addPolygonVertex(trianglator.addVertex(pt.x, pt.y))
+              vertices.extend([pt.x, pt.y, pt.z])
+              trianglator.addPolygonVertex(trianglator.addVertex((pt.x+pt2.x)/2, (pt.y+pt2.y)/2))
+              vertices.extend([(pt.x+pt2.x)/2, (pt.y+pt2.y)/2, (pt.z+pt2.z)/2])
+              total_vertices += 2
+              pt_count += 1
+
+            #add void points
+            for i in range(len(voids)):
+              trianglator.beginHole()
+              pts = voids[i].as_points()
+              for pt in pts:
+                trianglator.addHoleVertex(trianglator.addVertex(pt.x, pt.y))
+                vertices.extend([pt.x, pt.y, pt.z])
+                total_vertices += 1
+
+            trianglator.triangulate()
+            i = 0
+            print(trianglator.getNumTriangles())
+            while i < trianglator.getNumTriangles():
+              tr = [trianglator.getTriangleV0(i),trianglator.getTriangleV1(i),trianglator.getTriangleV2(i)]
+              faces.extend([3, tr[0], tr[1], tr[2]])
+              i+=1
+            ran = range(0, total_vertices)
 
         col = featureColorfromNativeRenderer(feature, layer)
         colors = [col for i in ran] # apply same color for all vertices

--- a/speckle/converter/geometry/polygon.py
+++ b/speckle/converter/geometry/polygon.py
@@ -56,6 +56,7 @@ def polygonToSpeckle(geom, feature: QgsFeature, layer: QgsVectorLayer):
         ran = range(0, total_vertices)
         faces = [total_vertices]
         faces.extend([i for i in ran])
+        # else: https://docs.panda3d.org/1.10/python/reference/panda3d.core.Triangulator
 
         col = featureColorfromNativeRenderer(feature, layer)
         colors = [col for i in ran] # apply same color for all vertices

--- a/speckle/converter/geometry/polygon.py
+++ b/speckle/converter/geometry/polygon.py
@@ -93,7 +93,7 @@ def polygonToSpeckle(geom, feature: QgsFeature, layer: QgsVectorLayer):
 
             trianglator.triangulate()
             i = 0
-            print(trianglator.getNumTriangles())
+            #print(trianglator.getNumTriangles())
             while i < trianglator.getNumTriangles():
               tr = [trianglator.getTriangleV0(i),trianglator.getTriangleV1(i),trianglator.getTriangleV2(i)]
               faces.extend([3, tr[0], tr[1], tr[2]])
@@ -118,13 +118,14 @@ def polygonToNative(poly: Base) -> QgsPolygon:
     #print(polylineToNative(poly["boundary"]))
     
     polygon = QgsPolygon()
-    polygon.setExteriorRing(polylineToNative(poly["boundary"]))
+    try: # if it's indeed a polygon with QGIS properties
+        polygon.setExteriorRing(polylineToNative(poly["boundary"]))
+    except: return
     try:
-      for void in poly["voids"]: 
-        #print(polylineToNative(void))
-        polygon.addInteriorRing(polylineToNative(void))
-    except:
-      pass
+        for void in poly["voids"]: 
+            #print(polylineToNative(void))
+            polygon.addInteriorRing(polylineToNative(void))
+    except:pass
     #print(polygon)
     #print()
 

--- a/speckle/converter/geometry/polygon.py
+++ b/speckle/converter/geometry/polygon.py
@@ -12,7 +12,7 @@ from speckle.converter.geometry.polyline import (
     polylineFromVerticesToSpeckle,
     polylineToNative,
 )
-from speckle.converter.geometry.transform import featureColorfromNativeRenderer
+from speckle.converter.layers.symbology import featureColorfromNativeRenderer
 from speckle.logging import logger
 import math
 from PyQt5.QtGui import QColor
@@ -61,7 +61,7 @@ def polygonToSpeckle(geom, feature: QgsFeature, layer: QgsVectorLayer):
         colors = [col for i in ran] # apply same color for all vertices
         mesh = rasterToMesh(vertices, faces, colors)
         polygon.displayValue = mesh 
-        
+
         return polygon
     except: 
         logger.logToUser("Some polygons might be invalid", Qgis.Warning)

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -26,10 +26,7 @@ def polylineFromVerticesToSpeckle(vertices, closed):
         if closed and i == len(specklePts) - 1:
             continue
         polyline.value.extend([point.x, point.y, point.z])
-    #print(polyline)
-    #print(polyline.value)
     return polyline
-
 
 def polylineToSpeckle(poly: QgsLineString):
     """Converts a QgsLineString to Speckle"""
@@ -41,8 +38,10 @@ def polylineToSpeckle(poly: QgsLineString):
         if vert_list and leng and len(vert_list) == 3 and leng!= dist:
             return arcToSpeckle(poly)
     except:
-        return polylineFromVerticesToSpeckle(poly.vertices(), False)
-    return polylineFromVerticesToSpeckle(poly.vertices(), False)
+        pass
+    try: closed = poly.isClosed()
+    except: closed = False
+    return polylineFromVerticesToSpeckle(poly.vertices(), closed)
 
 def arcToSpeckle(poly: QgsCircularString):
     """Converts a QgsCircularString to Speckle"""
@@ -51,7 +50,6 @@ def arcToSpeckle(poly: QgsCircularString):
     arc.startPoint = pointToSpeckle(vert_list[0])
     arc.midPoint = pointToSpeckle(vert_list[1])
     arc.endPoint = pointToSpeckle(vert_list[2])
-
     return arc
     
 

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -102,7 +102,7 @@ def circleToNative(poly: Circle) -> QgsLineString:
 
 def polycurveToNative(poly: Polycurve) -> QgsLineString:
     points = []
-    curve = QgsMultiLineString()
+    curve = QgsLineString()
     try:
         for segm in poly.segments: # Line, Polyline, Curve, Arc, Circle
             if isinstance(segm,Line):  converted = lineToNative(segm) # QgsLineString
@@ -112,12 +112,19 @@ def polycurveToNative(poly: Polycurve) -> QgsLineString:
             elif isinstance(segm,Arc):  converted = arcToQgisPoints(segm) # QgsLineString
             else: # either return a part of the curve, of skip this segment and try next
                 logger.logToUser(f"Part of the polycurve cannot be converted", Qgis.Warning)
+                curve = QgsLineString(points)
                 return curve
-            if converted is not None: curve.addGeometry(converted)
+            if converted is not None: 
+                for pt in converted.vertices():
+                    if len(points)>0 and pt.x()== points[len(points)-1].x() and pt.y()== points[len(points)-1].y() and pt.z()== points[len(points)-1].z(): pass
+                    else: points.append(pt)
             else:
                 logger.logToUser(f"Part of the polycurve cannot be converted", Qgis.Warning)
+                curve = QgsLineString(points)
                 return curve
     except: curve = None
+
+    curve = QgsLineString(points)
     return curve
 
 def arcToQgisPoints(poly: Arc):

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -8,6 +8,7 @@ from qgis.core import (
 )
 
 from speckle.converter.layers.utils import get_scale_factor
+from typing import List, Union
 
 
 def polylineFromVerticesToSpeckle(vertices, closed):
@@ -28,9 +29,10 @@ def polylineFromVerticesToSpeckle(vertices, closed):
         polyline.value.extend([point.x, point.y, point.z])
     return polyline
 
-def polylineToSpeckle(poly: QgsLineString):
+def polylineToSpeckle(poly: Union[QgsLineString, QgsCircularString]):
     """Converts a QgsLineString to Speckle"""
-    # first check if it's circular
+    
+    '''# first check if it's circular
     try:
         vert_list = [pt for pt in poly.vertices()] 
         leng = poly.length()
@@ -39,6 +41,7 @@ def polylineToSpeckle(poly: QgsLineString):
             return arcToSpeckle(poly)
     except:
         pass
+    '''
     try: closed = poly.isClosed()
     except: closed = False
     return polylineFromVerticesToSpeckle(poly.vertices(), closed)

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -9,7 +9,7 @@ from qgis.core import (
 
 from speckle.converter.layers.utils import get_scale_factor
 from typing import List, Union
-from speckle.converter.geometry.transform import featureColorfromNativeRenderer
+from speckle.converter.layers.symbology import featureColorfromNativeRenderer
 #from PyQt5.QtGui import QColor
 
 

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -40,8 +40,12 @@ def lineToNative(line: Line) -> QgsLineString:
 
 def polylineToNative(poly: Polyline) -> QgsLineString:
     """Converts a Speckle Polyline to QgsLineString"""
-
-    return QgsLineString([pointToNative(pt) for pt in poly.as_points()])
+    if poly.closed is False: 
+        return QgsLineString([pointToNative(pt) for pt in poly.as_points()])
+    else:
+        ptList = poly.as_points()
+        ptList.append(poly.as_points()[0])
+        return QgsLineString([pointToNative(pt) for pt in ptList])
 
 def curveToNative(poly: Polyline) -> QgsLineString:
     """Converts a Speckle Polyline to QgsLineString"""

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -42,3 +42,8 @@ def polylineToNative(poly: Polyline) -> QgsLineString:
     """Converts a Speckle Polyline to QgsLineString"""
 
     return QgsLineString([pointToNative(pt) for pt in poly.as_points()])
+
+def curveToNative(poly: Polyline) -> QgsLineString:
+    """Converts a Speckle Polyline to QgsLineString"""
+
+    return QgsLineString([pointToNative(pt) for pt in poly.as_points()])

--- a/speckle/converter/geometry/polyline.py
+++ b/speckle/converter/geometry/polyline.py
@@ -22,6 +22,8 @@ def polylineFromVerticesToSpeckle(vertices, closed):
         if closed and i == len(specklePts) - 1:
             continue
         polyline.value.extend([point.x, point.y, point.z])
+    #print(polyline)
+    #print(polyline.value)
     return polyline
 
 

--- a/speckle/converter/geometry/transform.py
+++ b/speckle/converter/geometry/transform.py
@@ -4,7 +4,7 @@ from qgis.core import (
     QgsCoordinateTransform,
     QgsPointXY,
     QgsProject,  QgsCoordinateReferenceSystem, QgsCoordinateTransform,
-    Qgis, QgsWkbTypes, QgsPolygon, QgsPointXY, QgsPoint, QgsFeature, QgsVectorLayer
+    Qgis, QgsWkbTypes, QgsPolygon, QgsPointXY, QgsPoint, 
 )
 
 from PyQt5.QtGui import QColor
@@ -38,39 +38,3 @@ def reverseTransform(
     # inverse transformation: dest -> src
     src = xform.transform(dest, QgsCoordinateTransform.ReverseTransform)
     return src
-
-def featureColorfromNativeRenderer(feature: QgsFeature, layer: QgsVectorLayer):
-    # case with one color for the entire layer
-    renderer = layer.renderer()
-    try:
-        if renderer.type() == 'categorizedSymbol' or renderer.type() == '25dRenderer' or renderer.type() == 'invertedPolygonRenderer' or renderer.type() == 'mergedFeatureRenderer' or renderer.type() == 'RuleRenderer' or renderer.type() == 'nullSymbol' or renderer.type() == 'singleSymbol' or renderer.type() == 'graduatedSymbol':
-            #get color value
-            color = QColor.fromRgb(0,0,0)
-            if renderer.type() == 'singleSymbol':
-                color = renderer.symbol().color()
-            elif renderer.type() == 'categorizedSymbol':
-                color = renderer.sourceSymbol().color()
-                category = renderer.classAttribute() # get the name of attribute used for classification
-                for obj in renderer.categories():
-                    if str(obj.value()) == str(feature.attribute( category )): 
-                        color = obj.symbol().color()
-                        break
-            elif renderer.type() == 'graduatedSymbol':
-                color = renderer.sourceSymbol().color()
-                category = renderer.legendClassificationAttribute() # get the name of attribute used for classification
-                if renderer.graduatedMethod() == 0: #if the styling is by color (not by size)
-                    for obj in renderer.ranges():
-                        if feature.attribute( category ) >= obj.lowerValue() and feature.attribute( category ) <= obj.upperValue(): 
-                            color = obj.symbol().color()
-                            break
-            # construct RGB color
-            try: r, g, b = color.getRgb()[:3]
-            except: r, g, b = [int(i) for i in color.replace(" ","").split(",")[:3] ]
-            #rVal = color.red(); gVal = color.green(); bVal = color.blue()
-            #except: rVal = 0; gVal = 0; bVal = 0
-            col = (r<<16) + (g<<8) + b
-            return col
-        else:
-            return (0<<16) + (0<<8) + 0
-    except:
-        return (0<<16) + (0<<8) + 0

--- a/speckle/converter/geometry/transform.py
+++ b/speckle/converter/geometry/transform.py
@@ -41,28 +41,34 @@ def reverseTransform(
 
 def featureColorfromNativeRenderer(feature: QgsFeature, layer: QgsVectorLayer):
     # case with one color for the entire layer
+    renderer = layer.renderer()
     try:
-        if layer.renderer().type() == 'categorizedSymbol' or layer.renderer().type() == '25dRenderer' or layer.renderer().type() == 'invertedPolygonRenderer' or layer.renderer().type() == 'mergedFeatureRenderer' or layer.renderer().type() == 'RuleRenderer' or layer.renderer().type() == 'nullSymbol' or layer.renderer().type() == 'singleSymbol' or layer.renderer().type() == 'graduatedSymbol':
+        if renderer.type() == 'categorizedSymbol' or renderer.type() == '25dRenderer' or renderer.type() == 'invertedPolygonRenderer' or renderer.type() == 'mergedFeatureRenderer' or renderer.type() == 'RuleRenderer' or renderer.type() == 'nullSymbol' or renderer.type() == 'singleSymbol' or renderer.type() == 'graduatedSymbol':
             #get color value
             color = QColor.fromRgb(0,0,0)
-            if layer.renderer().type() == 'singleSymbol':
-                color = layer.renderer().symbol().color()
-            elif layer.renderer().type() == 'categorizedSymbol':
-                category = layer.renderer().classAttribute() # get the name of attribute used for classification
-                for obj in layer.renderer().categories():
+            if renderer.type() == 'singleSymbol':
+                color = renderer.symbol().color()
+            elif renderer.type() == 'categorizedSymbol':
+                color = renderer.sourceSymbol().color()
+                category = renderer.classAttribute() # get the name of attribute used for classification
+                for obj in renderer.categories():
                     if str(obj.value()) == str(feature.attribute( category )): 
                         color = obj.symbol().color()
                         break
-            elif layer.renderer().type() == 'graduatedSymbol':
-                category = layer.renderer().legendClassificationAttribute() # get the name of attribute used for classification
-                for obj in layer.renderer().ranges():
-                    if feature.attribute( category ) >= obj.lowerValue() and feature.attribute( category ) <= obj.upperValue(): 
-                        color = obj.symbol().color()
-                        break
+            elif renderer.type() == 'graduatedSymbol':
+                color = renderer.sourceSymbol().color()
+                category = renderer.legendClassificationAttribute() # get the name of attribute used for classification
+                if renderer.graduatedMethod() == 0: #if the styling is by color (not by size)
+                    for obj in renderer.ranges():
+                        if feature.attribute( category ) >= obj.lowerValue() and feature.attribute( category ) <= obj.upperValue(): 
+                            color = obj.symbol().color()
+                            break
             # construct RGB color
-            rVal = color.red(); gVal = color.green(); bVal = color.blue()
+            try: r, g, b = color.getRgb()[:3]
+            except: r, g, b = [int(i) for i in color.replace(" ","").split(",")[:3] ]
+            #rVal = color.red(); gVal = color.green(); bVal = color.blue()
             #except: rVal = 0; gVal = 0; bVal = 0
-            col = (rVal<<16) + (gVal<<8) + bVal
+            col = (r<<16) + (g<<8) + b
             return col
         else:
             return (0<<16) + (0<<8) + 0

--- a/speckle/converter/geometry/transform.py
+++ b/speckle/converter/geometry/transform.py
@@ -4,7 +4,11 @@ from qgis.core import (
     QgsCoordinateTransform,
     QgsPointXY,
     QgsProject,  QgsCoordinateReferenceSystem, QgsCoordinateTransform,
+    Qgis, QgsWkbTypes, QgsPolygon, QgsPointXY, QgsPoint, QgsFeature, QgsVectorLayer
 )
+
+from PyQt5.QtGui import QColor
+
 
 def transform(
     src: QgsPointXY,
@@ -34,3 +38,33 @@ def reverseTransform(
     # inverse transformation: dest -> src
     src = xform.transform(dest, QgsCoordinateTransform.ReverseTransform)
     return src
+
+def featureColorfromNativeRenderer(feature: QgsFeature, layer: QgsVectorLayer):
+    # case with one color for the entire layer
+    try:
+        if layer.renderer().type() == 'categorizedSymbol' or layer.renderer().type() == '25dRenderer' or layer.renderer().type() == 'invertedPolygonRenderer' or layer.renderer().type() == 'mergedFeatureRenderer' or layer.renderer().type() == 'RuleRenderer' or layer.renderer().type() == 'nullSymbol' or layer.renderer().type() == 'singleSymbol' or layer.renderer().type() == 'graduatedSymbol':
+            #get color value
+            color = QColor.fromRgb(0,0,0)
+            if layer.renderer().type() == 'singleSymbol':
+                color = layer.renderer().symbol().color()
+            elif layer.renderer().type() == 'categorizedSymbol':
+                category = layer.renderer().classAttribute() # get the name of attribute used for classification
+                for obj in layer.renderer().categories():
+                    if str(obj.value()) == str(feature.attribute( category )): 
+                        color = obj.symbol().color()
+                        break
+            elif layer.renderer().type() == 'graduatedSymbol':
+                category = layer.renderer().legendClassificationAttribute() # get the name of attribute used for classification
+                for obj in layer.renderer().ranges():
+                    if feature.attribute( category ) >= obj.lowerValue() and feature.attribute( category ) <= obj.upperValue(): 
+                        color = obj.symbol().color()
+                        break
+            # construct RGB color
+            rVal = color.red(); gVal = color.green(); bVal = color.blue()
+            #except: rVal = 0; gVal = 0; bVal = 0
+            col = (rVal<<16) + (gVal<<8) + bVal
+            return col
+        else:
+            return (0<<16) + (0<<8) + 0
+    except:
+        return (0<<16) + (0<<8) + 0

--- a/speckle/converter/layers/Layer.py
+++ b/speckle/converter/layers/Layer.py
@@ -10,7 +10,7 @@ class Layer(Base, chunkable={"features": 100}):
         name=None,
         crs=None,
         features: List[Base] = [],
-        layerType: str = None,
+        layerType: str = "None",
         geomType: str = "None",
         renderer: dict = {},
         **kwargs
@@ -32,7 +32,7 @@ class RasterLayer(Base, chunkable={"features": 100}):
         crs=None,
         rasterCrs=None,
         features: List[Base] = [],
-        layerType: str = None,
+        layerType: str = "None",
         geomType: str = "None",
         renderer: dict = {},
         **kwargs

--- a/speckle/converter/layers/Layer.py
+++ b/speckle/converter/layers/Layer.py
@@ -12,6 +12,7 @@ class Layer(Base, chunkable={"features": 100}):
         features: List[Base] = [],
         layerType: str = None,
         geomType: str = "None",
+        renderer: dict = {},
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -20,3 +21,27 @@ class Layer(Base, chunkable={"features": 100}):
         self.type = layerType
         self.features = features
         self.geomType = geomType
+        self.renderer = renderer 
+
+class RasterLayer(Base, chunkable={"features": 100}):
+    """A GIS Layer"""
+
+    def __init__(
+        self,
+        name=None,
+        crs=None,
+        rasterCrs=None,
+        features: List[Base] = [],
+        layerType: str = None,
+        geomType: str = "None",
+        renderer: dict = {},
+        **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+        self.name = name
+        self.crs = crs
+        self.rasterCrs = rasterCrs
+        self.type = layerType
+        self.features = features
+        self.geomType = geomType
+        self.renderer = renderer 

--- a/speckle/converter/layers/__init__.py
+++ b/speckle/converter/layers/__init__.py
@@ -124,17 +124,17 @@ def cadLayerToNative(layerContentList:Base, layerName: str, streamId: str, branc
     #if layer.type is None:
     #    # Handle this case
     #    return
-    print(layerContentList)
+    #print(layerContentList)
     geom_points = []
     geom_polylines = []
     geom_polygones = []
     geom_meshes = []
     #filter speckle objects by type within each layer, create sub-layer for each type (points, lines, polygons, mesh?)
     for geom in layerContentList:
-        print(geom)
+        #print(geom)
         if geom.speckle_type == "Objects.Geometry.Point": 
             geom_points.append(geom)
-        if geom.speckle_type == "Objects.Geometry.Line" or geom.speckle_type == "Objects.Geometry.Polyline" or geom.speckle_type == "Objects.Geometry.Curve" or geom.speckle_type == "Objects.Geometry.Polycurve":
+        if geom.speckle_type == "Objects.Geometry.Line" or geom.speckle_type == "Objects.Geometry.Polyline" or geom.speckle_type == "Objects.Geometry.Curve" or geom.speckle_type == "Objects.Geometry.Arc" or geom.speckle_type == "Objects.Geometry.Circle" or geom.speckle_type == "Objects.Geometry.Polycurve":
             geom_polylines.append(geom)
     
     layer_points = cadVectorLayerToNative(geom_points, layerName, "Points", streamId+"_"+branch)
@@ -147,6 +147,8 @@ def cadVectorLayerToNative(geomList, layerName: str, geomType: str, streamBranch
     vl = None
     layerName = layerName + "/" + geomType
     crs = QgsProject.instance().crs() #QgsCoordinateReferenceSystem.fromWkt(layer.crs.wkt)
+    if crs.isGeographic is True: 
+        logger.logToUser(f"Project CRS is set to Geographic type, and objects in linear units might not be received correctly", Qgis.Warning)
 
     #CREATE A GROUP "received blabla" with sublayers
     newGroupName = f'{streamBranch}_latest'

--- a/speckle/converter/layers/__init__.py
+++ b/speckle/converter/layers/__init__.py
@@ -116,6 +116,12 @@ def layerToNative(layer: Layer, streamId: str) -> Union[QgsVectorLayer, QgsRaste
         return rasterLayerToNative(layer, streamId)
     return None
 
+def nonQgisToNative(layer: Layer, streamId: str) -> Union[QgsVectorLayer, QgsRasterLayer, None]:
+    layerType = type(layer.type)
+    if layer.type is None:
+        # Handle this case
+        return
+    return None
 
 def vectorLayerToNative(layer: Layer, streamId: str):
     vl = None

--- a/speckle/converter/layers/__init__.py
+++ b/speckle/converter/layers/__init__.py
@@ -7,11 +7,12 @@ from osgeo import (  # # C:\Program Files\QGIS 3.20.2\apps\Python39\Lib\site-pac
     gdal, osr)
 from qgis.core import (Qgis, QgsRasterLayer,
                        QgsVectorLayer, QgsProject, 
-                       QgsLayerTree, QgsLayerTreeGroup, QgsLayerTreeNode, QgsCoordinateReferenceSystem,
-                       QgsFields)
+                       QgsLayerTree, QgsLayerTreeGroup, QgsLayerTreeNode, 
+                       QgsCoordinateReferenceSystem, QgsCoordinateTransform,
+                       QgsFields, QgsRenderContext, QgsLayout, QgsFeatureRenderer)
 from speckle.converter.geometry.point import pointToNative
 from speckle.converter.layers.CRS import CRS
-from speckle.converter.layers.Layer import Layer
+from speckle.converter.layers.Layer import Layer, RasterLayer
 from speckle.converter.layers.feature import featureToSpeckle, rasterFeatureToSpeckle, featureToNative, cadFeatureToNative
 from speckle.converter.layers.utils import getLayerGeomType, getVariantFromValue, getLayerAttributes
 from speckle.logging import logger
@@ -53,6 +54,7 @@ def layerToSpeckle(layer, projectCRS, project): #now the input is QgsVectorLayer
     layerObjs = []
     # Convert CRS to speckle, use the projectCRS
     speckleReprojectedCrs = CRS(name=projectCRS.authid(), wkt=projectCRS.toWkt(), units=units) 
+    layerCRS = CRS(name=crs.authid(), wkt=crs.toWkt(), units=units) 
 
     if isinstance(selectedLayer, QgsVectorLayer):
 
@@ -63,8 +65,22 @@ def layerToSpeckle(layer, projectCRS, project): #now the input is QgsVectorLayer
             b = featureToSpeckle(fieldnames, f, crs, projectCRS, project, selectedLayer)
             layerObjs.append(b)
         # Convert layer to speckle
-        layerBase = Layer(layerName, speckleReprojectedCrs, layerObjs, "VectorLayer", getLayerGeomType(selectedLayer))
+        layerBase = Layer(name=layerName, crs=speckleReprojectedCrs, features=layerObjs, type="VectorLayer", geomType=getLayerGeomType(selectedLayer))
         layerBase.applicationId = selectedLayer.id()
+
+        layerRenderer = selectedLayer.renderer()
+        layerRendererType = layerRenderer.type() #Polylines: "singleSymbol"
+        layerRendererLegendSymbolItemsList = layerRenderer.legendSymbolItems() #list
+
+        layout = QgsLayout(QgsProject.instance())
+        smth = layout.referenceMap()
+        mapContext = QgsRenderContext()
+        try: mapContext = QgsRenderContext.fromMapSettings(smth.mapSettings())
+        except: pass
+
+        layerLegendItems = [{'symbol': {'color':it.symbol().color(),'opacity':it.symbol().opacity(),'usedAttributes':it.symbol().usedAttributes(mapContext)}, 'label': it.label(), 'checkable': it.isCheckable()} for it in layerRendererLegendSymbolItemsList]
+
+        #layerBase.
         return layerBase
 
     if isinstance(selectedLayer, QgsRasterLayer):
@@ -72,40 +88,9 @@ def layerToSpeckle(layer, projectCRS, project): #now the input is QgsVectorLayer
         b = rasterFeatureToSpeckle(selectedLayer, projectCRS, project)
         layerObjs.append(b)
         # Convert layer to speckle
-        layerBase = Layer(layerName, speckleReprojectedCrs, layerObjs, "RasterLayer")
+        layerBase = RasterLayer(name=layerName, crs=speckleReprojectedCrs, rasterCrs=layerCRS, features=layerObjs, type="RasterLayer")
         layerBase.applicationId = selectedLayer.id()
         return layerBase
-
-
-def receiveRaster(project, source_folder, name, epsg, rasterDimensions, bands, rasterBandVals, pt, rasterResXY): 
-    ## https://opensourceoptions.com/blog/pyqgis-create-raster/
-    # creating file in temporary folder: https://stackoverflow.com/questions/56038742/creating-in-memory-qgsrasterlayer-from-the-rasterization-of-a-qgsvectorlayer-wit
-    #print(source_folder)
-    fn = source_folder + '/' + name + '.tif' #'_received_raster.tif'
-    #print(fn)
-
-    driver = gdal.GetDriverByName('GTiff')
-    # create raster dataset
-    ds = driver.Create(fn, xsize=rasterDimensions[0], ysize=rasterDimensions[1], bands=bands, eType=gdal.GDT_Float32)
-
-    # Write data to raster band
-    for i in range(bands):
-        rasterband = np.array(rasterBandVals[i])
-        rasterband = np.reshape(rasterband,(rasterDimensions[1], rasterDimensions[0]))
-        ds.GetRasterBand(i+1).WriteArray(rasterband) # or "rasterband.T"
-
-    # create GDAL transformation in format [top-left x coord, cell width, 0, top-left y coord, 0, cell height]
-    ds.SetGeoTransform([pt.x(), rasterResXY[0], 0, pt.y(), 0, rasterResXY[1]])
-    # create a spatial reference object
-    srs = osr.SpatialReference()
-    #  For the Universal Transverse Mercator the SetUTM(Zone, North=1 or South=2)
-    srs.ImportFromEPSG(epsg) # from https://gis.stackexchange.com/questions/34082/creating-raster-layer-from-numpy-array-using-pyqgis
-    ds.SetProjection(srs.ExportToWkt())
-    # close the rater datasource by setting it equal to None
-    ds = None
-    raster_layer = QgsRasterLayer(fn, name, 'gdal')
-    project.addMapLayer(raster_layer)
-    return raster_layer
 
 
 def layerToNative(layer: Layer, streamId: str, branchName: str) -> Union[QgsVectorLayer, QgsRasterLayer, None]:
@@ -302,10 +287,43 @@ def vectorLayerToNative(layer: Layer, streamBranch: str):
         vl.updateExtents()
         vl.commitChanges()
         layerGroup.addLayer(vl)
+
+        #renderer = vl.renderer()
+
         return vl
 
-def rasterLayerToNative(layer: Layer, streamBranch: str):
-    # testing, only for receiving layers
+def rasterLayerToNative(layer: RasterLayer, streamBranch: str):
+
+    vl = None
+    crs = QgsCoordinateReferenceSystem.fromWkt(layer.crs.wkt) #moved up, because CRS of existing layer needs to be rewritten
+    crsRaster = QgsCoordinateReferenceSystem.fromWkt(layer.rasterCrs.wkt) #moved up, because CRS of existing layer needs to be rewritten
+
+    #CREATE A GROUP "received blabla" with sublayers
+    newGroupName = f'{streamBranch}_latest'
+    root = QgsProject.instance().layerTreeRoot()
+    layerGroup = QgsLayerTreeGroup(newGroupName)
+
+    if root.findGroup(newGroupName) is not None:
+        layerGroup = root.findGroup(newGroupName)
+    else:
+        root.addChildNode(layerGroup)
+    layerGroup.setExpanded(True)
+
+    #find ID of the layer with a matching name in the "latest" group 
+    newName = f'{streamBranch}_latest/{layer.name}'
+    childId = None
+    for child in layerGroup.children(): 
+        if child.name() == newName: 
+            childId = child.layerId()
+            break
+    # modify existing layer (if exists) 
+    if QgsProject.instance().mapLayer(childId) is not None:
+        #existingRaster = QgsProject.instance().mapLayer(childId)
+        QgsProject.instance().removeMapLayer(childId)
+
+    
+
+    ######################## testing, only for receiving layers #################
     source_folder = QgsProject.instance().absolutePath()
 
     if(source_folder == ""):
@@ -314,16 +332,52 @@ def rasterLayerToNative(layer: Layer, streamBranch: str):
 
     project = QgsProject.instance()
     projectCRS = QgsCoordinateReferenceSystem.fromWkt(layer.crs.wkt)
-    epsg = int(str(projectCRS).split(":")[len(str(projectCRS).split(":"))-1].split(">")[0])
+    crsid = crsRaster.authid()
+    try: epsg = int(crsid.split(":")[1]) 
+    except: 
+        epsg = int(str(projectCRS).split(":")[len(str(projectCRS).split(":"))-1].split(">")[0])
+        logger.logToUser(f"CRS of the received raster cannot be identified. Project CRS will be used.", Qgis.Warning)
     
     feat = layer.features[0]
     bandNames = feat["Band names"]
     bandValues = [feat["@(10000)" + name + "_values"] for name in bandNames]
 
-    newName = f'{streamBranch}_latest_{layer.name}'
-    receiveRaster(project, source_folder, newName, epsg, [feat["X pixels"],feat["Y pixels"]],  feat["Band count"], bandValues, pointToNative(feat["displayValue"][0]), [feat["X resolution"],feat["Y resolution"]])
+    #newName = f'{streamBranch}_latest_{layer.name}'
+
+    ###########################################################################
+
+    ## https://opensourceoptions.com/blog/pyqgis-create-raster/
+    # creating file in temporary folder: https://stackoverflow.com/questions/56038742/creating-in-memory-qgsrasterlayer-from-the-rasterization-of-a-qgsvectorlayer-wit
+
+    fn = source_folder + '/' + newName.replace("/","_") + '.tif' #'_received_raster.tif'
+    driver = gdal.GetDriverByName('GTiff')
+    # create raster dataset
+    ds = driver.Create(fn, xsize=feat["X pixels"], ysize=feat["Y pixels"], bands=feat["Band count"], eType=gdal.GDT_Float32)
+
+    # Write data to raster band
+    for i in range(feat["Band count"]):
+        rasterband = np.array(bandValues[i])
+        rasterband = np.reshape(rasterband,(feat["Y pixels"], feat["X pixels"]))
+        ds.GetRasterBand(i+1).WriteArray(rasterband) # or "rasterband.T"
+
+    # create GDAL transformation in format [top-left x coord, cell width, 0, top-left y coord, 0, cell height]
+    pt = pointToNative(feat["displayValue"][0])
+    xform = QgsCoordinateTransform(crs, crsRaster, project)
+    pt.transform(xform)
+    ds.SetGeoTransform([pt.x(), feat["X resolution"], 0, pt.y(), 0, feat["Y resolution"]])
+    # create a spatial reference object
+    srs = osr.SpatialReference()
+    #  For the Universal Transverse Mercator the SetUTM(Zone, North=1 or South=2)
+    srs.ImportFromEPSG(epsg) # from https://gis.stackexchange.com/questions/34082/creating-raster-layer-from-numpy-array-using-pyqgis
+    ds.SetProjection(srs.ExportToWkt())
+    # close the rater datasource by setting it equal to None
+    ds = None
+
+    raster_layer = QgsRasterLayer(fn, newName, 'gdal')
+    QgsProject.instance().addMapLayer(raster_layer, False)
+    layerGroup.addLayer(raster_layer)
     
-    return None
+    return raster_layer
 
 
 '''

--- a/speckle/converter/layers/__init__.py
+++ b/speckle/converter/layers/__init__.py
@@ -188,7 +188,7 @@ def cadVectorLayerToNative(geomList, layerName: str, geomType: str, streamBranch
             
             pr.addAttributes(newFields) # add new attributes from the current object
             fetIds.append(f.id)
-            try: fetColors.append(f.displayStyle.color), print(str(f.id)+ ': ' + str(f.displayStyle.color))
+            try: fetColors.append(f.displayStyle.color) #, print(str(f.id)+ ': ' + str(f.displayStyle.color))
             except: fetColors.append(None)
         #else: geomList.remove(f)
     

--- a/speckle/converter/layers/__init__.py
+++ b/speckle/converter/layers/__init__.py
@@ -13,6 +13,7 @@ from speckle.converter.layers.Layer import Layer
 from speckle.converter.layers.feature import featureToSpeckle, rasterFeatureToSpeckle, featureToNative
 from speckle.converter.layers.utils import getLayerGeomType, getVariantFromValue, getLayerAttributes
 from speckle.logging import logger
+from specklepy.objects import Base
 
 import numpy as np
 
@@ -116,18 +117,25 @@ def layerToNative(layer: Layer, streamId: str) -> Union[QgsVectorLayer, QgsRaste
         return rasterLayerToNative(layer, streamId)
     return None
 
-def nonQgisToNative(layer: Layer, streamId: str) -> Union[QgsVectorLayer, QgsRasterLayer, None]:
-    layerType = type(layer.type)
-    if layer.type is None:
-        # Handle this case
-        return
+def nonQgisToNative(layerContentList:Base, layerName: str, streamId: str) -> Union[QgsVectorLayer, QgsRasterLayer, None]:
+    #layerType = QgsVectorLayer
+    #if layer.type is None:
+    #    # Handle this case
+    #    return
+    print(layerContentList)
+    #TODO: filter speckle objects by type within each layer, create sub-layer for each type (points, lines, polygons, mesh?)
+    recreateVectorLayer(layerContentList)
     return None
+
+def recreateVectorLayer(layerContentList): 
+    #TODO get Project CRS, use it by default for the new received layer
+    return
 
 def vectorLayerToNative(layer: Layer, streamId: str):
     vl = None
     crs = QgsCoordinateReferenceSystem.fromWkt(layer.crs.wkt) #moved up, because CRS of existing layer needs to be rewritten
 
-    ## CREATE A GROUP "received blabla" with sublayers
+    #TODO CREATE A GROUP "received blabla" with sublayers
     newName = f'{streamId}_latest_{layer.name}'
     for lyr in QgsProject.instance().mapLayers().values(): 
         #print(lyr.name())

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -218,7 +218,8 @@ def featureToNative(feature: Base, attrs):
         except: pass
 
         try: 
-            if feature["applicationId"]: dynamicProps.append("id")
+            if feature["applicationId"] and "id" not in dynamicProps: dynamicProps.append("id")
+            dynamicProps.remove("applicationId")
         except: 
             pass
         dynamicProps.sort()

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -289,21 +289,20 @@ def cadFeatureToNative(feature: Base, attrs: QgsFields):
         # add new field names from current geometry  
         # and make an attribute list to pass for layer creation
         for name in dynamicProps:
-            if name not in attrs.names(): 
+            if name not in attrs.names() and name not in ['displayStyle', 'id', 'renderMaterial', 'userDictionary', 'userStrings']: 
 
                 variant = getVariantFromValue(feature[name])
                 if variant: 
-                    if name == "id": fields.append( QgsField(name, QVariant.Int) )
+                    if name == "applicationId": fields.append( QgsField("id", QVariant.Int) )
                     else: fields.append( QgsField(name, variant) )
                 else: fields.append( QgsField(name, QVariant.String) )
 
         # assign fields and their values to the feature
         feat.setFields(fields)
         for f in fields.toList():
-        #for name in dynamicProps:
             try: value = feature[f.name()]
             except: value = None
-            if name == "id": 
+            if f.name() == "id": 
                 try: value = int(feature["applicationId"])
                 except: value = None
             feat[f.name()] = value

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -333,7 +333,7 @@ def cadFeatureToNative(feature: Base, attrs: QgsFields, layerName: str):
                     feat[fName] = str(value) 
                     if len(str(value)) > 255: feat[fName] = str(value)[:255]
                 except: feat[fName] = None
-        elif f.type() == QVariant.Double:
+        elif f.type() == QVariant.Double: # 6
             if isinstance(value, float): feat[fName] = float(value)
             else:
                 logger.logToUser(f"Value of the attribute '{fName}' of the layer '{layerName}' might be skipped due to type discrepancies", Qgis.Warning)

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -109,7 +109,7 @@ def rasterFeatureToSpeckle(selectedLayer, projectCRS, project):
     count = 0
     rendererType = selectedLayer.renderer().type()
     #print(rendererType)
-    # TODO identify symbology type and if Multiband, which band is which color
+    # identify symbology type and if Multiband, which band is which color
     for v in range(rasterDimensions[1] ): #each row, Y
         for h in range(rasterDimensions[0] ): #item in a row, X
             pt1 = QgsPointXY(rasterOriginPoint.x()+h*rasterResXY[0], rasterOriginPoint.y()+v*rasterResXY[1])
@@ -200,7 +200,9 @@ def rasterFeatureToSpeckle(selectedLayer, projectCRS, project):
 def featureToNative(feature: Base):
     feat = QgsFeature()
     try: # ignore 'broken' geometry
-        speckle_geom = feature["geometry"]
+        try: speckle_geom = feature["geometry"] # for created in QGIS Layer type
+        except:  speckle_geom = feature # for created in other software
+
         if isinstance(speckle_geom, list):
             qgsGeom = geometry.convertToNativeMulti(speckle_geom)
         else:
@@ -209,7 +211,9 @@ def featureToNative(feature: Base):
         if qgsGeom is not None:
             feat.setGeometry(qgsGeom)
         dynamicProps = feature.get_dynamic_member_names()
-        dynamicProps.remove("geometry")
+        try: dynamicProps.remove("geometry")
+        except: pass
+
         if feature["applicationId"]: dynamicProps.append("id")
         dynamicProps.sort()
         fields = QgsFields()
@@ -219,6 +223,8 @@ def featureToNative(feature: Base):
             except: 
                 dynamicProps.remove(name)
                 pass #print(error)
+        #TODO return attribute values
+        '''
         feat.setFields(fields)
         for name in dynamicProps:
             corrected = name
@@ -230,6 +236,7 @@ def featureToNative(feature: Base):
                     value = None
             feat[corrected] = value
             #https://qgis.org/pyqgis/master/core/QgsFeature.html#qgis.core.QgsFeature.setAttribute
+        '''
         return feat
     except:
         return ""

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -214,7 +214,9 @@ def featureToNative(feature: Base):
         try: dynamicProps.remove("geometry")
         except: pass
 
-        if feature["applicationId"]: dynamicProps.append("id")
+        try: 
+          if feature["applicationId"]: dynamicProps.append("id")
+        except: pass
         dynamicProps.sort()
         fields = QgsFields()
         for name in dynamicProps:

--- a/speckle/converter/layers/feature.py
+++ b/speckle/converter/layers/feature.py
@@ -274,11 +274,14 @@ def cadFeatureToNative(feature: Base, attrs: QgsFields):
 
         #get object properties to add as attributes
         dynamicProps = feature.get_dynamic_member_names()
+        dynamicProps.append("_Speckle_ID")
+
         try: dynamicProps.remove("geometry")
         except: pass
 
-        try: 
-            if feature["applicationId"]: dynamicProps.append("id")
+        try:
+            if feature["applicationId"] and "id" not in dynamicProps: dynamicProps.append("id")
+            dynamicProps.remove("applicationId")
         except: pass
         dynamicProps.sort()
 
@@ -292,7 +295,9 @@ def cadFeatureToNative(feature: Base, attrs: QgsFields):
         for name in dynamicProps:
             if name not in attrs.names() and name not in ['displayStyle', 'id', 'renderMaterial', 'userDictionary', 'userStrings']: 
 
-                variant = getVariantFromValue(feature[name])
+                if name == '_Speckle_ID': variant = getVariantFromValue(feature['id'])
+                else: variant = getVariantFromValue(feature[name])
+
                 if variant: 
                     if name == "applicationId": fields.append( QgsField("id", QVariant.Int) )
                     else: fields.append( QgsField(name, variant) )

--- a/speckle/converter/layers/symbology.py
+++ b/speckle/converter/layers/symbology.py
@@ -256,13 +256,17 @@ def rendererToSpeckle(renderer: QgsFeatureRenderer or QgsRasterRenderer):
     elif rType == 'categorizedSymbol': 
         layerRenderer['properties'] = {'attribute': "", 'symbType': ""} #{'symbol':{}, 'ramp':{}, 'ranges':{}, 'gradMethod':"", 'symbType':"", 'legendClassificationAttribute': ""}
         attribute = renderer.classAttribute() # 'id'
+        layerRenderer['properties']['attribute'] = attribute
         symbol = renderer.sourceSymbol()
-        symbType = symbol.symbolTypeToString(symbol.type()) #Line
-        try: r, g, b = symbol.color().getRgb()[:3]
-        except: [int(i) for i in symbol.color().replace(" ","").split(',')[:3] ]
-        sourceSymbColor = (r<<16) + (g<<8) + b
+        sourceSymbColor = (0<<16) + (0<<8) + 0
+        try:
+            symbType = symbol.symbolTypeToString(symbol.type()) #Line
+            try: r, g, b = symbol.color().getRgb()[:3]
+            except: [int(i) for i in symbol.color().replace(" ","").split(',')[:3] ]
+            sourceSymbColor = (r<<16) + (g<<8) + b
 
-        layerRenderer['properties'].update( {'attribute': attribute, 'symbType': symbType} )
+            layerRenderer['properties'].update( {'attribute': attribute, 'symbType': symbType} )
+        except: pass
         
         categories = renderer.categories() #<qgis._core.QgsRendererCategory object at 0x00000155E8786A60>
         layerRenderer['properties']['categories'] = []

--- a/speckle/converter/layers/symbology.py
+++ b/speckle/converter/layers/symbology.py
@@ -1,0 +1,361 @@
+
+from qgis.core import (
+    QgsRasterRenderer, QgsFeatureRenderer, 
+    QgsFeature, QgsVectorLayer,
+    QgsGradientColorRamp, QgsGradientStop, 
+    QgsGradientStop, QgsRendererRange,
+    QgsSingleBandGrayRenderer, 
+    QgsPalettedRasterRenderer, QgsMultiBandColorRenderer,
+    QgsContrastEnhancement,
+    QgsSymbol, QgsWkbTypes, QgsRendererCategory,
+    QgsCategorizedSymbolRenderer, QgsSingleSymbolRenderer,
+    QgsGraduatedSymbolRenderer, QgsRasterDataProvider
+
+)
+from speckle.converter.layers.Layer import Layer, RasterLayer
+from PyQt5.QtGui import QColor
+
+def featureColorfromNativeRenderer(feature: QgsFeature, layer: QgsVectorLayer):
+    # case with one color for the entire layer
+    renderer = layer.renderer()
+    try:
+        if renderer.type() == 'categorizedSymbol' or renderer.type() == '25dRenderer' or renderer.type() == 'invertedPolygonRenderer' or renderer.type() == 'mergedFeatureRenderer' or renderer.type() == 'RuleRenderer' or renderer.type() == 'nullSymbol' or renderer.type() == 'singleSymbol' or renderer.type() == 'graduatedSymbol':
+            #get color value
+            color = QColor.fromRgb(0,0,0)
+            if renderer.type() == 'singleSymbol':
+                color = renderer.symbol().color()
+            elif renderer.type() == 'categorizedSymbol':
+                color = renderer.sourceSymbol().color()
+                category = renderer.classAttribute() # get the name of attribute used for classification
+                for obj in renderer.categories():
+                    if str(obj.value()) == str(feature.attribute( category )): 
+                        color = obj.symbol().color()
+                        break
+            elif renderer.type() == 'graduatedSymbol':
+                color = renderer.sourceSymbol().color()
+                category = renderer.legendClassificationAttribute() # get the name of attribute used for classification
+                if renderer.graduatedMethod() == 0: #if the styling is by color (not by size)
+                    for obj in renderer.ranges():
+                        if feature.attribute( category ) >= obj.lowerValue() and feature.attribute( category ) <= obj.upperValue(): 
+                            color = obj.symbol().color()
+                            break
+            # construct RGB color
+            try: r, g, b = color.getRgb()[:3]
+            except: r, g, b = [int(i) for i in color.replace(" ","").split(",")[:3] ]
+            col = (r<<16) + (g<<8) + b
+            return col
+        else: return (0<<16) + (0<<8) + 0
+    except: return (0<<16) + (0<<8) + 0
+
+def gradientColorRampToSpeckle(rRamp: QgsGradientColorRamp):
+    props = rRamp.properties() # {'color1': '255,255,255,255', 'color2': '255,0,0,255', 'discrete': '0', 'rampType': 'gradient'}
+    stops = rRamp.stops() #[]
+    stopsStr = []
+    for s in stops:
+        try: r, g, b = s.color.getRgb()[:3]
+        except: r, g, b = [int(i) for i in s.color.replace(" ","").split(',')[:3] ]
+        sColor = (r<<16) + (g<<8) + b
+        stopsStr.append({'color':sColor, 'offset':s.offset})
+    rampType = rRamp.type() #'gradient'
+    sourceRamp = props
+    sourceRamp.update({'stops': stopsStr, 'rampType':rampType})
+
+    return sourceRamp
+
+def gradientColorRampToNative(renderer):
+    ramp = renderer['properties']['ramp'] # {discrete, rampType, stops}
+    newRamp = None
+    try: # if it's not a random color ramp
+        oldStops = ramp['stops']
+        stops = []
+        for i in range(len(oldStops)):
+            rgb = oldStops[i]['color']
+            r = (rgb & 0xFF0000) >> 16
+            g = (rgb & 0xFF00) >> 8
+            b = rgb & 0xFF 
+            sColor = QColor.fromRgb(r, g, b)
+            s = QgsGradientStop(oldStops[i]['offset'], sColor)
+            stops.append(s)
+
+        c11,c12,c13,alpa1 = ramp['color1'].split(',')
+        color1 = QColor.fromRgb(int(c11),int(c12),int(c13))
+        c21,c22,c23,alpha2 = ramp['color2'].split(',')
+        color2 = QColor.fromRgb(int(c21),int(c22),int(c23))
+        discrete = int(ramp['discrete'])
+        newRamp = QgsGradientColorRamp(color1,color2,discrete,stops)
+    except: pass
+    return newRamp
+
+def vectorRendererToNative(layer: Layer):
+    renderer = layer.renderer 
+    rendererNew = None 
+    if renderer and renderer['type']:
+        if renderer['type']  == 'categorizedSymbol':
+            attribute = renderer['properties']['attribute']
+            cats = renderer['properties']['categories']
+
+            categories = []
+            noneVal = 0
+            for i in range(len(cats)):
+                v = cats[i]['value'] 
+                if v is None: noneVal +=1
+                rgb = cats[i]['symbColor']
+                r = (rgb & 0xFF0000) >> 16
+                g = (rgb & 0xFF00) >> 8
+                b = rgb & 0xFF 
+                color = QColor.fromRgb(r, g, b)
+                symbol = QgsSymbol.defaultSymbol(QgsWkbTypes.geometryType(QgsWkbTypes.parseType(layer.geomType)))
+                # create an extra category for possible future feature
+                #if len(categories)==0: 
+                #    symbol.setColor(QColor.fromRgb(0,0,0))
+                #    categories.append(QgsRendererCategory())
+                #    categories[0].setSymbol(symbol)
+                #    categories[0].setLabel('Other')
+
+                symbol.setColor(color)
+                categories.append(QgsRendererCategory(cats[i]['value'], symbol, cats[i]['label'], True) )
+            # create empty category for all other values (if doesn't exist yet)
+            if noneVal == 0:
+                symbol2 = symbol.clone()
+                symbol2.setColor(QColor.fromRgb(0,0,0))
+                cat = QgsRendererCategory()
+                cat.setSymbol(symbol2)
+                cat.setLabel('Other')
+                categories.append(cat)
+            
+            rendererNew = QgsCategorizedSymbolRenderer(attribute, categories)
+
+        elif renderer['type'] == 'singleSymbol':
+            rgb = renderer['properties']['symbol']['symbColor']
+            r = (rgb & 0xFF0000) >> 16
+            g = (rgb & 0xFF00) >> 8
+            b = rgb & 0xFF 
+            color = QColor.fromRgb(r, g, b)
+            symbol = QgsSymbol.defaultSymbol(QgsWkbTypes.geometryType(QgsWkbTypes.parseType(layer.geomType)))
+            symbol.setColor(color)
+            rendererNew = QgsSingleSymbolRenderer(symbol)
+        
+        elif renderer['type'] == 'graduatedSymbol':
+            attribute = renderer['properties']['attribute']
+            gradMetod = renderer['properties']['gradMethod'] # by color or by size
+            rgb = renderer['properties']['sourceSymbColor'] 
+            r = (rgb & 0xFF0000) >> 16
+            g = (rgb & 0xFF00) >> 8
+            b = rgb & 0xFF 
+            sourceSymbColor = QColor.fromRgb(r, g, b)
+            
+            if gradMetod == 0:
+                ramp = renderer['properties']['ramp'] # {discrete, rampType, stops}
+                ranges = renderer['properties']['ranges'] # []
+                newRamp = gradientColorRampToNative(renderer) #QgsGradientColorRamp
+
+                newRanges = []
+                for i in range(len(ranges)):
+                    rgb = ranges[i]['symbColor']
+                    r = (rgb & 0xFF0000) >> 16
+                    g = (rgb & 0xFF00) >> 8
+                    b = rgb & 0xFF 
+                    color = QColor.fromRgb(r, g, b)
+                    width = ranges[i]['symbColor']
+                    symbol = QgsSymbol.defaultSymbol(QgsWkbTypes.geometryType(QgsWkbTypes.parseType(layer.geomType)))
+                    symbol.setColor(color)
+                    newRanges.append(QgsRendererRange(ranges[i]['lower'],ranges[i]['upper'],symbol,ranges[i]['label'],True) )
+                try: 
+                    rendererNew = QgsGraduatedSymbolRenderer(attribute, newRanges)
+                    rendererNew.setSourceColorRamp(newRamp)
+                    sourceSymbol = QgsSymbol.defaultSymbol(QgsWkbTypes.geometryType(QgsWkbTypes.parseType(layer.geomType)))
+                    sourceSymbol.setColor(sourceSymbColor)
+                    rendererNew.setSourceSymbol(sourceSymbol)
+                except: rendererNew = QgsGraduatedSymbolRenderer()
+                rendererNew.setGraduatedMethod(gradMetod)
+
+            else:
+                rgb = renderer['properties']['sourceSymbColor']
+                r = (rgb & 0xFF0000) >> 16
+                g = (rgb & 0xFF00) >> 8
+                b = rgb & 0xFF 
+                color = QColor.fromRgb(r, g, b)
+                symbol = QgsSymbol.defaultSymbol(QgsWkbTypes.geometryType(QgsWkbTypes.parseType(layer.geomType)))
+                symbol.setColor(color)
+                rendererNew = QgsSingleSymbolRenderer(symbol)
+    return rendererNew
+
+def rasterRendererToNative(layer: RasterLayer, rInterface: QgsRasterDataProvider):
+    renderer = layer.renderer
+    rendererNew = None
+    if renderer and renderer['type']:
+        if renderer['type']  == 'singlebandgray':
+            band = renderer['properties']['band']
+            contrast = QgsContrastEnhancement()
+            contrast.setContrastEnhancementAlgorithm(int(renderer['properties']['contrast']))
+            contrast.setMaximumValue(float(renderer['properties']['max']))
+            contrast.setMinimumValue(float(renderer['properties']['min']))
+            
+            rendererNew = QgsSingleBandGrayRenderer(rInterface,int(band))
+            rendererNew.setContrastEnhancement(contrast)
+
+        if renderer['type']  == 'multibandcolor':
+            redBand = renderer['properties']['redBand']
+            greenBand = renderer['properties']['greenBand']
+            blueBand = renderer['properties']['blueBand']
+            rendererNew = QgsMultiBandColorRenderer(rInterface,int(redBand),int(greenBand),int(blueBand))
+            try:
+                contrastR = QgsContrastEnhancement()
+                contrastR.setContrastEnhancementAlgorithm(int(renderer['properties']['redContrast']))
+                contrastR.setMaximumValue(float(renderer['properties']['redMax']))
+                contrastR.setMinimumValue(float(renderer['properties']['redMin']))
+                rendererNew.setRedContrastEnhancement(contrastR)
+            except: pass
+            try:
+                contrastG = QgsContrastEnhancement()
+                contrastG.setContrastEnhancementAlgorithm(int(renderer['properties']['greenContrast']))
+                contrastG.setMaximumValue(float(renderer['properties']['greenMax']))
+                contrastG.setMinimumValue(float(renderer['properties']['greenMin']))
+                rendererNew.setGreenContrastEnhancement(contrastG)
+            except: pass
+            try:
+                contrastB = QgsContrastEnhancement()
+                contrastB.setContrastEnhancementAlgorithm(int(renderer['properties']['blueContrast']))
+                contrastB.setMaximumValue(float(renderer['properties']['blueMax']))
+                contrastB.setMinimumValue(float(renderer['properties']['blueMin']))
+                rendererNew.setBlueContrastEnhancement(contrastB)
+            except: pass
+
+        if renderer['type']  == 'paletted':
+            band = renderer['properties']['band']
+            classes = renderer['properties']['classes']
+            newRamp = gradientColorRampToNative(renderer) #QgsGradientColorRamp
+            newClasses = []
+            for i in classes:
+                rgb = i['color']
+                r = (rgb & 0xFF0000) >> 16
+                g = (rgb & 0xFF00) >> 8
+                b = rgb & 0xFF 
+                color = QColor.fromRgb(r, g, b)
+                newClasses.append(QgsPalettedRasterRenderer.Class(float(i['value']),color,i['label']))
+
+            rendererNew = QgsPalettedRasterRenderer(rInterface,int(band),newClasses)
+    
+    return rendererNew
+    
+def rendererToSpeckle(renderer: QgsFeatureRenderer or QgsRasterRenderer):
+    rType = renderer.type() # 'singleSymbol','categorizedSymbol','graduatedSymbol',
+    layerRenderer = {}
+    layerRenderer['type'] = rType
+
+    if rType == 'singleSymbol': 
+        layerRenderer['properties'] = {'symbol':{}, 'symbType':""}
+
+        symbol = renderer.symbol() # QgsLineSymbol
+        symbType = symbol.symbolTypeToString(symbol.type()) #Line
+        try: rgb = symbol.color().getRgb()
+        except: [int(i) for i in symbol().color().replace(" ","").split(',')[:3] ]
+        symbolColor = (rgb[0]<<16) + (rgb[1]<<8) + rgb[2]
+        layerRenderer['properties'].update({'symbol':{'symbColor': symbolColor}, 'symbType':symbType})
+
+    elif rType == 'categorizedSymbol': 
+        layerRenderer['properties'] = {'attribute': "", 'symbType': ""} #{'symbol':{}, 'ramp':{}, 'ranges':{}, 'gradMethod':"", 'symbType':"", 'legendClassificationAttribute': ""}
+        attribute = renderer.classAttribute() # 'id'
+        symbol = renderer.sourceSymbol()
+        symbType = symbol.symbolTypeToString(symbol.type()) #Line
+        try: r, g, b = symbol.color().getRgb()[:3]
+        except: [int(i) for i in symbol.color().replace(" ","").split(',')[:3] ]
+        sourceSymbColor = (r<<16) + (g<<8) + b
+
+        layerRenderer['properties'].update( {'attribute': attribute, 'symbType': symbType} )
+        
+        categories = renderer.categories() #<qgis._core.QgsRendererCategory object at 0x00000155E8786A60>
+        layerRenderer['properties']['categories'] = []
+        for i in categories:
+            value = i.value()
+            try: r, g, b = i.symbol().color().getRgb()[:3]
+            except: [int(i) for i in i.symbol().color().replace(" ","").split(',')[:3] ]
+            symbColor = (r<<16) + (g<<8) + b
+            symbOpacity = i.symbol().opacity() # QgsSymbol.color()
+            label = i.label() 
+            layerRenderer['properties']['categories'].append({'value':value,'symbColor':symbColor,'symbOpacity':symbOpacity, 'sourceSymbColor': sourceSymbColor,'label':label})
+            
+    elif rType == 'graduatedSymbol': 
+        layerRenderer['properties'] = {'symbol':{}, 'ramp':{}, 'ranges':{}, 'gradMethod':"", 'symbType':""}
+
+        attribute = renderer.legendClassificationAttribute() # 'id'
+        symbol = renderer.sourceSymbol() # QgsLineSymbol
+        symbType = symbol.symbolTypeToString(symbol.type()) #Line
+        try: r, g, b = symbol.color().getRgb()[:3]
+        except: r, g, b = [int(i) for i in symbol.color().replace(" ","").split(',')[:3] ]
+        sourceSymbColor = (r<<16) + (g<<8) + b
+        gradMethod = renderer.graduatedMethod() # 0
+        layerRenderer['properties'].update( {'attribute': attribute, 'symbType': symbType, 'gradMethod': gradMethod, 'sourceSymbColor': sourceSymbColor} )
+
+        rRamp = renderer.sourceColorRamp() # QgsGradientColorRamp
+        if isinstance(rRamp,QgsGradientColorRamp) : 
+            layerRenderer['properties']['ramp'] = gradientColorRampToSpeckle(rRamp)
+
+        rRanges = renderer.ranges() # [QgsRendererRange,...]
+        layerRenderer['properties']['ranges'] = []
+        for i in rRanges:
+            if isinstance(i, QgsRendererRange):
+                lower = i.lowerValue()
+                upper = i.upperValue()
+                rgb = i.symbol().color().getRgb() # QgsSymbol.color() -> QColor
+                symbColor = (rgb[0]<<16) + (rgb[1]<<8) + rgb[2]
+                symbOpacity = i.symbol().opacity() # QgsSymbol.color()
+                label = i.label() 
+                width = 0.26
+                try: width = i.width()
+                except: pass
+                # {'label': '1 - 1.4', 'lower': 1.0, 'symbColor': <PyQt5.QtGui.QColor ...BD9B9D4A0>, 'symbOpacity': 1.0, 'upper': 1.4}
+                layerRenderer['properties']['ranges'].append({'lower':lower,'upper':upper,'symbColor':symbColor,'symbOpacity':symbOpacity,'label':label,'width':width})
+     
+    elif rType == "singlebandgray":  
+        band = renderer.grayBand()
+        contrast = renderer.contrastEnhancement().contrastEnhancementAlgorithm()
+        mmin = renderer.contrastEnhancement().minimumValue()
+        mmax = renderer.contrastEnhancement().maximumValue()
+        layerRenderer = {'type': 'singlebandgray', 'properties': {'max':mmax,'min':mmin,'band':band,'contrast':contrast}}
+    elif rType == "multibandcolor":  
+        redBand = renderer.redBand()
+        greenBand = renderer.greenBand()
+        blueBand = renderer.blueBand() 
+        redContrast = redMin = redMax = greenContrast = greenMin = greenMax = blueContrast = blueMin = blueMax = None
+        try:
+            redContrast = renderer.redContrastEnhancement().contrastEnhancementAlgorithm()
+            redMin = renderer.redContrastEnhancement().minimumValue()
+            redMax = renderer.redContrastEnhancement().maximumValue()
+        except: pass
+        try:
+            greenContrast = renderer.greenContrastEnhancement().contrastEnhancementAlgorithm()
+            greenMin = renderer.greenContrastEnhancement().minimumValue()
+            greenMax = renderer.greenContrastEnhancement().maximumValue()
+        except: pass
+        try:
+            blueContrast = renderer.blueContrastEnhancement().contrastEnhancementAlgorithm()
+            blueMin = renderer.blueContrastEnhancement().minimumValue()
+            blueMax = renderer.blueContrastEnhancement().maximumValue()
+        except: pass
+        layerRenderer = {'type': 'multibandcolor', 'properties': {'greenBand':greenBand,'blueBand':blueBand,'redBand':redBand}}
+        layerRenderer['properties'].update({'redContrast':redContrast,'redMin':redMin,'redMax':redMax})
+        layerRenderer['properties'].update({'greenContrast':greenContrast,'greenMin':greenMin,'greenMax':greenMax})
+        layerRenderer['properties'].update({'blueContrast':blueContrast,'blueMin':blueMin,'blueMax':blueMax})
+
+    elif rType == "paletted":  
+        band = renderer.band()
+        rendererClasses = renderer.classes()
+        classes = []
+        rRamp = renderer.sourceColorRamp()
+        sourceRamp = {}
+        if isinstance(rRamp,QgsGradientColorRamp) : # or QgsRandomColorRamp
+            sourceRamp = gradientColorRampToSpeckle(rRamp) #rampType, stops,props(e.g.color)
+
+        for i in rendererClasses:
+            value = i.value 
+            rgb = i.color.getRgb()
+            color =  (rgb[0]<<16) + (rgb[1]<<8) + rgb[2]
+            classes.append({'color':color,'value':value,'label':i.label})
+        layerRenderer = {'type': 'paletted', 'properties': {'classes':classes,'ramp':sourceRamp,'band':band}}
+        
+    else: 
+        layerRenderer = {'type': 'Other', 'properties': {}}
+    return layerRenderer
+
+

--- a/speckle/converter/layers/utils.py
+++ b/speckle/converter/layers/utils.py
@@ -131,7 +131,7 @@ def getVariantFromValue(value):
     pairs = {
         str: QVariant.String,
         float: QVariant.Double,
-        int: QVariant.Int,
+        int: QVariant.LongLong,
         bool: QVariant.Bool
     }
     t = type(value)

--- a/speckle/converter/layers/utils.py
+++ b/speckle/converter/layers/utils.py
@@ -156,9 +156,9 @@ def getLayerAttributes(layer: Layer):
     names = {}
     for feature in layer.features:
         featNames = feature.get_member_names()
-
+        #create empty attribute fields
         for n in featNames:
-            if n == "totalChildrenCount":
+            if n == "totalChildrenCount" or n == "applicationId":
                 continue
             if not (n in names):
                 try:
@@ -172,11 +172,11 @@ def getLayerAttributes(layer: Layer):
     vals = []
     sorted_names = list(names.keys())
     sorted_names.sort()
-    
+    #sort fields
     for i in sorted_names: #names.values():
         corrected = i
-        if corrected == "id": continue
-        if corrected == "applicationId": corrected = "id"
+        #if corrected == "id": continue
+        #if corrected == "applicationId": corrected = "id"
         vals.append(names[corrected])
     return vals 
 

--- a/speckle/converter/layers/utils.py
+++ b/speckle/converter/layers/utils.py
@@ -1,7 +1,6 @@
 from PyQt5.QtCore import QVariant
-from qgis._core import QgsVectorLayer, QgsWkbTypes, QgsField
+from qgis._core import Qgis, QgsVectorLayer, QgsWkbTypes, QgsField
 from speckle.logging import logger
-
 from speckle.converter.layers import Layer
 
 
@@ -128,6 +127,7 @@ def getLayerGeomType(layer: QgsVectorLayer): #https://qgis.org/pyqgis/3.0/core/W
 
 
 def getVariantFromValue(value):
+    # TODO add Base object
     pairs = {
         str: QVariant.String,
         float: QVariant.Double,
@@ -135,7 +135,10 @@ def getVariantFromValue(value):
         bool: QVariant.Bool
     }
     t = type(value)
-    return pairs[t]
+    res = None
+    try: res = pairs[t]
+    except: pass
+    return res
 
 
 def get_type(type_name):
@@ -176,3 +179,26 @@ def getLayerAttributes(layer: Layer):
         if corrected == "applicationId": corrected = "id"
         vals.append(names[corrected])
     return vals 
+
+def get_scale_factor(units):
+    unit_scale = {
+    "meters": 1.0,
+    "centimeters": 0.01,
+    "millimeters": 0.001,
+    "inches": 0.0254,
+    "feet": 0.3048,
+    "kilometers": 1000.0,
+    "mm": 0.001,
+    "cm": 0.01,
+    "m": 1.0,
+    "km": 1000.0,
+    "in": 0.0254,
+    "ft": 0.3048,
+    "yd": 0.9144,
+    "mi": 1609.340,
+    }
+    if units.lower() in unit_scale.keys():
+        return unit_scale[units]
+    logger.logToUser(f"Units {units} are not supported.", Qgis.Warning)
+    return 1.0
+

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -366,8 +366,8 @@ class SpeckleQGIS:
             commitObj = operations.receive(objId, transport, None)
             logger.log(f"Succesfully received {objId}")
 
-            if QgsProject.instance().crs().isGeographic() is True: 
-                logger.logToUser("Project CRS of Geographic type (e.g. EPSG 4326) cannot be used while receiving CAD geometry. Please set the project CRS to Projected type (e.g. EPSG:32631)", Qgis.Warning)
+            if QgsProject.instance().crs().isGeographic() is True or QgsProject.instance().crs().isValid() is False: 
+                logger.logToUser("Unsupported Project CRS. CRS of Geographic type (e.g. EPSG 4326) cannot be used while receiving CAD geometry. Please set the project CRS to Projected type (e.g. EPSG:32631)", Qgis.Warning)
                 return
 
             if app == "QGIS": check: Callable[[Base], bool] = lambda base: isinstance(base, Layer) 

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -531,9 +531,11 @@ class SpeckleQGIS:
             if b.name == branchName:
                 branch = b
                 break
-        self.dockwidget.commitDropdown.addItems(
-            [f"{commit.id}"+ " | " + f"{commit.message}" for commit in branch.commits.items]
-        )
+        try:
+            self.dockwidget.commitDropdown.addItems(
+                [f"{commit.id}"+ " | " + f"{commit.message}" for commit in branch.commits.items]
+            )
+        except: pass
 
     def reloadUI(self):
         self.is_setup = self.check_for_accounts()
@@ -595,6 +597,9 @@ class SpeckleQGIS:
             )
             self.dockwidget.streamList.itemSelectionChanged.connect(
                 self.onActiveStreamChanged
+            )
+            self.dockwidget.streamBranchDropdown.currentIndexChanged.connect(
+                self.populateActiveCommitDropdown
             )
 
             self.get_project_streams()

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -406,7 +406,7 @@ class SpeckleQGIS:
             
             if app != "QGIS": 
                 if QgsProject.instance().crs().isGeographic() is True or QgsProject.instance().crs().isValid() is False: 
-                    logger.logToUser("Unsupported Project CRS. CRS of Geographic type (e.g. EPSG 4326) cannot be used while receiving CAD geometry. Please set the project CRS to Projected type (e.g. EPSG:32631)", Qgis.Warning)
+                    logger.logToUser("Please set the project CRS to Projected type to receive CAD geometry (e.g. EPSG:32631), or create a custom one from geographic coordinates", Qgis.Warning)
                     return
             logger.log(f"Succesfully received {objId}")
 
@@ -719,19 +719,9 @@ class SpeckleQGIS:
             # https://gis.stackexchange.com/questions/379199/having-problem-with-proj-string-for-custom-coordinate-system
             # https://proj.org/usage/projections.html
             
-            #testCrsString = "+proj=tmerc +datum=WGS84 +lon_0=-75 +k_0=0.9996 +x_0=0 +y_0=0"
-            testCrsString = "+proj=tmerc +ellps=WGS84 +datum=WGS84 +units=m +no_defs +lon_0=" + str(self.lon) + " +x_0=0 +y_0=0 +k_0=0.9996"
-            testCrs = QgsCoordinateReferenceSystem().fromProj(testCrsString)
-
-            sPoint = QgsPointXY(self.lon, self.lat)
-            transformContext = QgsProject.instance().transformContext()
-            xform = QgsCoordinateTransform(QgsCoordinateReferenceSystem(4326), testCrs, transformContext)
-            newPoint = xform.transform(sPoint)
-            
-            newCrsString = "+proj=tmerc +ellps=WGS84 +datum=WGS84 +units=m +no_defs +lon_0=" + str(self.lon) + " +x_0=0 +y_0=" + str(-1*newPoint.y()) + " +k_0=0.9996"
+            newCrsString = "+proj=tmerc +ellps=WGS84 +datum=WGS84 +units=m +no_defs +lon_0=" + str(self.lon) + " lat_0=" + str(self.lat) + " +x_0=0 +y_0=0 +k_0=1"
             newCrs = QgsCoordinateReferenceSystem().fromProj(newCrsString)#fromWkt(newProjWkt)
             validate = QgsCoordinateReferenceSystem().createFromProj(newCrsString)
-            newId = 911911
 
             if validate: 
                 QgsProject.instance().setCrs(newCrs) 

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -359,8 +359,8 @@ class SpeckleQGIS:
             commitObj = operations.receive(objId, transport, None)
             logger.log(f"Succesfully received {objId}")
 
-            #check: Callable[[Base], bool] = lambda base: isinstance(base, Layer)
-            check: Callable[[Base], bool] = lambda base: True
+            check: Callable[[Base], bool] = lambda base: isinstance(base, Layer) or isinstance(base, Base)
+            #check: Callable[[Base], bool] = lambda base: True
 
             def callback(base: Base) -> bool:
                 print(base)
@@ -370,10 +370,13 @@ class SpeckleQGIS:
                     if layer is not None:
                         logger.log("Layer created: " + layer.name())
                 else:
-                    print("it is NOT a Layer")
-                    layer = nonQgisToNative(base, streamId)
-                    if layer is not None:
-                        logger.log("Layer created: " + layer.name())
+                    print("it is a Base")
+                    print(base.get_dynamic_member_names())
+                    layerList = base.get_dynamic_member_names()
+                    for l in layerList:
+                        layer = nonQgisToNative(base[l], l, streamId)
+                        if layer is not None: 
+                            logger.log("Layer group created: " + layer.name())
                 return True
 
             traverseObject(commitObj, callback, check)

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -423,13 +423,11 @@ class SpeckleQGIS:
                 if isinstance(value, List):
                     for item in value:
                         loopVal(item, name)
-                        try: # in case "speckle_type" not applicable
-                            if item.speckle_type.startswith("Objects.Geometry."): 
-                                pt, pl = cadLayerToNative(value, name, streamId, branch.name)
-                                if pt is not None: logger.log("Layer group created: " + pt.name())
-                                if pl is not None: logger.log("Layer group created: " + pl.name())
-                                break
-                        except: pass
+                        if item.speckle_type and item.speckle_type.startswith("Objects.Geometry."): 
+                            pt, pl = cadLayerToNative(value, name, streamId, branch.name)
+                            if pt is not None: logger.log("Layer group created: " + pt.name())
+                            if pl is not None: logger.log("Layer group created: " + pl.name())
+                            break
 
             traverseObject(commitObj, callback, check)
                 

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -39,6 +39,7 @@ from speckle.converter.layers import (
     convertSelectedLayers,
     getLayers,
     layerToNative,
+    nonQgisToNative,
 )
 from speckle.logging import logger
 from ui.add_stream_modal import AddStreamModalDialog
@@ -358,11 +359,19 @@ class SpeckleQGIS:
             commitObj = operations.receive(objId, transport, None)
             logger.log(f"Succesfully received {objId}")
 
-            check: Callable[[Base], bool] = lambda base: isinstance(base, Layer)
+            #check: Callable[[Base], bool] = lambda base: isinstance(base, Layer)
+            check: Callable[[Base], bool] = lambda base: True
 
             def callback(base: Base) -> bool:
+                print(base)
                 if isinstance(base, Layer):
+                    print("it is Layer")
                     layer = layerToNative(base, streamId)
+                    if layer is not None:
+                        logger.log("Layer created: " + layer.name())
+                else:
+                    print("it is NOT a Layer")
+                    layer = nonQgisToNative(base, streamId)
                     if layer is not None:
                         logger.log("Layer created: " + layer.name())
                 return True
@@ -547,6 +556,7 @@ class SpeckleQGIS:
     def get_project_streams(self):
         proj = QgsProject().instance()
         saved_streams = proj.readEntry("speckle-qgis", "project_streams", "")
+        ######### need to check whether saved streams are available (account reachable)
         if saved_streams[1] and len(saved_streams[0]) != 0:
             temp = []
             for url in saved_streams[0].split(","):

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -39,7 +39,7 @@ from speckle.converter.layers import (
     convertSelectedLayers,
     getLayers,
     layerToNative,
-    nonQgisToNative,
+    cadLayerToNative,
 )
 from speckle.logging import logger
 from ui.add_stream_modal import AddStreamModalDialog
@@ -394,21 +394,17 @@ class SpeckleQGIS:
 
             def loopVal(value, name): # "name" is the parent object/property/layer name
                 if isinstance(value, Base): 
-                    #print("BASE")
-                    #print(value)
                     try: # dont go through parts of Speckle Geometry object
                         if value.speckle_type.startswith("Objects.Geometry."): pass
                         else: loopObj(value, name)
                     except: loopObj(value, name)
 
                 if isinstance(value, List):
-                    #print("LIST")
-                    #print(value)
                     for item in value:
                         loopVal(item, name)
                         try: # in case "speckle_type" not applicable
                             if item.speckle_type.startswith("Objects.Geometry."): 
-                                pt, pl = nonQgisToNative(value, name, streamId, branch.name)
+                                pt, pl = cadLayerToNative(value, name, streamId, branch.name)
                                 if pt is not None: logger.log("Layer group created: " + pt.name())
                                 if pl is not None: logger.log("Layer group created: " + pl.name())
                                 break
@@ -453,9 +449,11 @@ class SpeckleQGIS:
             return
 
         self.dockwidget.streamList.clear()
-        self.dockwidget.streamList.addItems(
-            [f"{stream[1].name} - {stream[1].id}" for stream in self.current_streams]
-        )
+        try:
+            self.dockwidget.streamList.addItems(
+                [f"{stream[1].name} - {stream[1].id}" for stream in self.current_streams]
+            )
+        except: return
 
     def populateActiveStreamBranchDropdown(self):
         if not self.dockwidget:

--- a/speckle_qgis.py
+++ b/speckle_qgis.py
@@ -35,7 +35,7 @@ import webbrowser
 # Initialize Qt resources from file resources.py
 from resources import *
 from speckle.converter.layers import (
-    Layer,
+    Layer, RasterLayer,
     convertSelectedLayers,
     getLayers,
     layerToNative,
@@ -105,7 +105,7 @@ class SpeckleQGIS:
         # Save reference to the QGIS interface
         self.dockwidget = None
         self.iface = iface
-        self.qgis_project = QgsProject().instance()
+        self.qgis_project = QgsProject.instance()
 
         self.lat = 0.0
         self.lon = 0.0
@@ -394,11 +394,11 @@ class SpeckleQGIS:
                     return
             logger.log(f"Succesfully received {objId}")
 
-            if app == "QGIS": check: Callable[[Base], bool] = lambda base: isinstance(base, Layer) 
+            if app == "QGIS": check: Callable[[Base], bool] = lambda base: isinstance(base, Layer) or isinstance(base, RasterLayer)
             else: check: Callable[[Base], bool] = lambda base: isinstance(base, Base)
 
             def callback(base: Base) -> bool:
-                if isinstance(base, Layer):
+                if isinstance(base, Layer) or isinstance(base, RasterLayer):
                     layer = layerToNative(base, streamId, branch.name)
                     if layer is not None:
                         logger.log("Layer created: " + layer.name())

--- a/ui/add_stream_modal.py
+++ b/ui/add_stream_modal.py
@@ -43,7 +43,7 @@ class AddStreamModalDialog(QtWidgets.QWidget, FORM_CLASS):
         query = self.search_text_field.text()
         results = self.speckle_client.stream.search(query)
         self.stream_results = results
-        print(results)
+        #print(results)
         self.populateResultsList()
     
     def populateResultsList(self):

--- a/ui/add_stream_modal.py
+++ b/ui/add_stream_modal.py
@@ -43,6 +43,7 @@ class AddStreamModalDialog(QtWidgets.QWidget, FORM_CLASS):
         query = self.search_text_field.text()
         results = self.speckle_client.stream.search(query)
         self.stream_results = results
+        print(results)
         self.populateResultsList()
     
     def populateResultsList(self):
@@ -64,7 +65,7 @@ class AddStreamModalDialog(QtWidgets.QWidget, FORM_CLASS):
     def onAccountSelected(self, index):
         account = self.speckle_accounts[index]
         self.speckle_client = SpeckleClient(account.serverInfo.url, account.serverInfo.url.startswith("https"))
-        self.speckle_client.authenticate(token=account.token)
+        self.speckle_client.authenticate_with_token(token=account.token)
 
     def populate_accounts_dropdown(self):
         # Populate the accounts comboBox

--- a/ui/speckle_qgis_dialog_base.ui
+++ b/ui/speckle_qgis_dialog_base.ui
@@ -119,24 +119,34 @@
          <widget class="QComboBox" name="streamBranchDropdown"/>
         </item>
         <item row="4" column="0">
+         <widget class="QLabel" name="commitLabel">
+          <property name="text">
+           <string>Commit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="commitDropdown"/>
+        </item>
+        <item row="5" column="0">
          <widget class="QLabel" name="layersLabel">
           <property name="text">
            <string>Layer</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QListWidget" name="layersWidget">
           <property name="selectionMode">
            <enum>QAbstractItemView::MultiSelection</enum>
           </property>
          </widget>
         </item>
-        
+
         <item row="6" column="0">
          <widget class="QLabel" name="surveyPointLabel">
           <property name="text">
-           <string>Survey Point (lat,lon)</string>
+           <string>Lat, Lon</string>
           </property>
          </widget>
         </item>
@@ -149,7 +159,6 @@
                 </property>
               </widget>
             </item>
-
             <item>
               <widget class="QLineEdit" name="surveyPointLon">
                 <property name="placeholderText">
@@ -157,36 +166,37 @@
                 </property>
               </widget>
             </item>
-            
+            <item>
+            <widget class="QPushButton" name="saveSurveyPoint">
+              <property name="enabled">
+                <bool>true</bool>
+              </property>
+              <property name="text">
+                <string>Create Custom CRS</string>
+              </property>
+            </widget>
+          </item>
+
           </layout>
         </item>
 
-        <item row="7" column="1">
-          <widget class="QPushButton" name="saveSurveyPoint">
-            <property name="enabled">
-            <bool>true</bool>
-            </property>
-            <property name="text">
-            <string>Create Custom Project CRS (based on Transverse Mercator)</string>
-            </property>
-          </widget>
-        </item>
+        
 
-        <item row="8" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="messageLabel">
           <property name="text">
            <string>Message</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="7" column="1">
          <widget class="QLineEdit" name="messageInput">
           <property name="placeholderText">
            <string>Sent XXX objects from QGIS</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="8" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QPushButton" name="reloadButton">
@@ -217,6 +227,7 @@
           </item>
          </layout>
         </item>
+
        </layout>
       </item>
      </layout>

--- a/ui/speckle_qgis_dialog_base.ui
+++ b/ui/speckle_qgis_dialog_base.ui
@@ -132,21 +132,61 @@
           </property>
          </widget>
         </item>
+        
         <item row="6" column="0">
+         <widget class="QLabel" name="surveyPointLabel">
+          <property name="text">
+           <string>Survey Point (lat,lon)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+              <widget class="QLineEdit" name="surveyPointLat">
+                <property name="placeholderText">
+                <string>0.0</string>
+                </property>
+              </widget>
+            </item>
+
+            <item>
+              <widget class="QLineEdit" name="surveyPointLon">
+                <property name="placeholderText">
+                <string>0.0</string>
+                </property>
+              </widget>
+            </item>
+            
+          </layout>
+        </item>
+
+        <item row="7" column="1">
+          <widget class="QPushButton" name="saveSurveyPoint">
+            <property name="enabled">
+            <bool>true</bool>
+            </property>
+            <property name="text">
+            <string>Create Custom Project CRS (based on Transverse Mercator)</string>
+            </property>
+          </widget>
+        </item>
+
+        <item row="8" column="0">
          <widget class="QLabel" name="messageLabel">
           <property name="text">
            <string>Message</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="8" column="1">
          <widget class="QLineEdit" name="messageInput">
           <property name="placeholderText">
            <string>Sent XXX objects from QGIS</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="9" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QPushButton" name="reloadButton">


### PR DESCRIPTION
## Changelog

### Features

- Speckle geometry types now supported in QGIS: Point, Line, Polyline, Arc, Circle, Polycurve
- QGIS to QGIS layers keep the symbology (single color, categorized and graduated by color)
- QGIS geometry writes and reads Speckle displayStyle.color property (when receiving, it creates individual color category for each object in the layer based on _Speckle_ID attribute)
- Speckle properties upon receiving are stored in the attribute table (except 'applicationId','bbox','displayStyle', 'renderMaterial', 'userDictionary', 'userStrings','geometry')
- Option to receive older commits
- Supporting polygons with holes export (to mesh) using [[panda3d](https://github.com/panda3d/panda3d)](https://github.com/panda3d/panda3d) (added mid-point for better triangulation)
- Creating custom CRS for receiving and sending geometry intended for non-GIS software (lat and lon values required)

### Improvements

- Received geometry stored in a group (streamID+ streamName + commitID)
- Warning before sending empty list of streams
- Marking Streams as not accessible if necessary

### Tech fixes:

- QVariant.Int → to Qvariant.LongLong (doesn’t break on large integers)
- Check the Speckle units before receiving, scale if necessary
- Separate RasterLayer class, add “rasterCrs” attribute to keep matched the units in which raster is received, and the data about pixel size.