### PR TITLE
CI: Use contexts and ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,18 @@ jobs:
     docker:
       - image: cimg/base:2021.01
     steps:
-      - run: # Could not get ssh to work, so using a personal token
+      - add_ssh_keys:
+          fingerprints:
+            - "03:2e:ee:4f:14:67:2b:88:32:e8:cc:f0:cb:df:92:29"
+      - run:
+          name: I know Github as a host
+          command: |
+            mkdir ~/.ssh
+            touch ~/.ssh/known_hosts
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
           name: Clone
-          command: git clone https://$GITHUB_TOKEN@github.com/specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools 
+          command: git clone git@github.com:specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
       - persist_to_workspace:
           root: ./
           paths:
@@ -191,3 +200,4 @@ workflows: #happens with every PR to main
               only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
+          context: do-spaces-speckle-releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "03:2e:ee:4f:14:67:2b:88:32:e8:cc:f0:cb:df:92:29"
+            - "d1:d5:96:4d:ed:58:6e:7f:58:cc:21:5f:94:20:76:49"
       - run:
           name: I know Github as a host
           command: |


### PR DESCRIPTION
Related to CircleCI security warning.

We now use ssh for `get-ci-tools` step, and use contexts to pass in any env vars to specific jobs.